### PR TITLE
Add read-only DDD repository contracts and EF base types

### DIFF
--- a/DomainDrivenDesign/Core/Repositories/IReadOnlyRepository.cs
+++ b/DomainDrivenDesign/Core/Repositories/IReadOnlyRepository.cs
@@ -1,0 +1,12 @@
+namespace Odin.DDD.Repositories
+{
+    /// <summary>
+    /// Represents a read-only repository for aggregate roots.
+    /// Concrete repository contracts should expose domain-specific read operations.
+    /// </summary>
+    /// <typeparam name="TAggregateRoot">The type of the aggregate root.</typeparam>
+    public interface IReadOnlyRepository<TAggregateRoot> : IAsyncDisposable
+        where TAggregateRoot : class, IAggregateRoot
+    {
+    }
+}

--- a/DomainDrivenDesign/Core/Repositories/IRepository.cs
+++ b/DomainDrivenDesign/Core/Repositories/IRepository.cs
@@ -1,10 +1,10 @@
 namespace Odin.DDD.Repositories
 {
     /// <summary>
-    /// Represents a repository for persisting entities to a data store.
+    /// Represents a read-write repository for persisting aggregate roots to a data store.
     /// </summary>
     /// <typeparam name="TAggregateRoot">The type of the aggregate root.</typeparam>
-    public interface IRepository<TAggregateRoot> : IAsyncDisposable
+    public interface IRepository<TAggregateRoot> : IReadOnlyRepository<TAggregateRoot>
         where TAggregateRoot : class, IAggregateRoot
     {
         /// <summary>

--- a/DomainDrivenDesign/Repositories-EF/EntityFrameworkReadOnlyIdentityRepositoryBase.cs
+++ b/DomainDrivenDesign/Repositories-EF/EntityFrameworkReadOnlyIdentityRepositoryBase.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using System.Numerics;
+
+namespace Odin.DDD.Repositories
+{
+    /// <summary>
+    /// Provides a base implementation for read-only repositories of 'Identity' AggregateRoot entities
+    /// that uses Entity Framework Core for data access.
+    /// </summary>
+    /// <typeparam name="TAggregateRoot">The aggregate root type.</typeparam>
+    /// <typeparam name="TId">The aggregate root identity type.</typeparam>
+    /// <typeparam name="TDbContext">The database context that must contain a DBSet of <typeparamref name="TAggregateRoot"/>.</typeparam>
+    public abstract class EntityFrameworkReadOnlyIdentityRepositoryBase<TAggregateRoot, TId, TDbContext>
+        : EntityFrameworkReadOnlyRepositoryBase<TAggregateRoot, TDbContext>
+        where TAggregateRoot : class, IIdentityAggregateRoot<TId>
+        where TId : struct, IEqualityOperators<TId, TId, bool>
+        where TDbContext : DbContext
+    {
+        /// <summary>
+        /// EntityFrameworkReadOnlyIdentityRepositoryBase constructor.
+        /// </summary>
+        /// <param name="dbContext">The Entity Framework database context.</param>
+        protected EntityFrameworkReadOnlyIdentityRepositoryBase(TDbContext dbContext)
+            : base(dbContext)
+        {
+        }
+
+        /// <summary>
+        /// Returns a list of aggregate root IDs that match the given specification.
+        /// </summary>
+        /// <param name="specification">The query specification.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>The aggregate root IDs that match the query specification.</returns>
+        protected Task<IReadOnlyList<TId>> FetchIdsAsync(
+            IQuerySpecification<TAggregateRoot> specification,
+            CancellationToken ct = default)
+        {
+            return FetchManyAsync(specification, aggregateRoot => aggregateRoot.Id, ct);
+        }
+    }
+}

--- a/DomainDrivenDesign/Repositories-EF/EntityFrameworkReadOnlyRepositoryBase.cs
+++ b/DomainDrivenDesign/Repositories-EF/EntityFrameworkReadOnlyRepositoryBase.cs
@@ -1,0 +1,225 @@
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+
+namespace Odin.DDD.Repositories
+{
+    /// <summary>
+    /// Provides a base implementation for read-only repositories that use Entity Framework Core for data access.
+    /// Exposes protected FetchSingleAsync and FetchManyAsync query endpoints for concrete repository methods.
+    /// </summary>
+    /// <typeparam name="TAggregateRoot">The aggregate root type.</typeparam>
+    /// <typeparam name="TDbContext">The database context that must contain a DBSet of <typeparamref name="TAggregateRoot"/>.</typeparam>
+    public abstract class EntityFrameworkReadOnlyRepositoryBase<TAggregateRoot, TDbContext>
+        : IReadOnlyRepository<TAggregateRoot>, IDisposable
+        where TDbContext : DbContext
+        where TAggregateRoot : class, IAggregateRoot
+    {
+        /// <summary>
+        /// The context for database operations.
+        /// </summary>
+        protected readonly TDbContext DbContext;
+
+        /// <summary>
+        /// The DbSet for the aggregate root type, TAggregateRoot.
+        /// </summary>
+        protected readonly DbSet<TAggregateRoot> DbSet;
+
+        /// <summary>
+        /// EntityFrameworkReadOnlyRepositoryBase constructor.
+        /// </summary>
+        /// <param name="dbContext">The Entity Framework database context.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        protected EntityFrameworkReadOnlyRepositoryBase(TDbContext dbContext)
+        {
+            ArgumentNullException.ThrowIfNull(dbContext);
+            DbContext = dbContext;
+            // If TAggregateRoot is a base type of the actual implementation type in the database context
+            // then this exception will be thrown which is no good.
+            // if (DbContext.Model.FindEntityType(typeof(TAggregateRoot)) == null)
+            // {
+            //     throw new InvalidOperationException(
+            //         $"The DbContext does not contain a DbSet for aggregate root type {typeof(TAggregateRoot).FullName}.");
+            // }
+            DbSet = DbContext.Set<TAggregateRoot>();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether queries should be created without EF change tracking.
+        /// </summary>
+        protected virtual bool UseNoTrackingQueries
+        {
+            get { return true; }
+        }
+
+        /// <summary>
+        /// Queries the repository based on the query specification.
+        /// </summary>
+        /// <param name="fetchManySpec">The query specification.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>The aggregate roots that match the query specification.</returns>
+        protected async Task<IReadOnlyList<TAggregateRoot>> FetchManyAsync(
+            IQuerySpecification<TAggregateRoot> fetchManySpec, CancellationToken ct = default)
+        {
+            return await ApplySpecification(fetchManySpec).ToListAsync(ct);
+        }
+
+        /// <summary>
+        /// Queries the repository based on the query specification, projecting TAggregateRoot
+        /// to TProjection.
+        /// </summary>
+        /// <param name="specification">The query specification.</param>
+        /// <param name="projection">The projection to apply.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <typeparam name="TProjection">The projection result type.</typeparam>
+        /// <returns>The projected results that match the query specification.</returns>
+        protected async Task<IReadOnlyList<TProjection>> FetchManyAsync<TProjection>(
+            IQuerySpecification<TAggregateRoot> specification,
+            Expression<Func<TAggregateRoot, TProjection>> projection,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(projection);
+
+            return await ApplySpecification(specification)
+                .Select(projection)
+                .ToListAsync(ct);
+        }
+
+        /// <summary>
+        /// Queries the repository based on the projection query specification, projecting TAggregateRoot
+        /// to TProjection.
+        /// </summary>
+        /// <param name="specification">The projection query specification.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <typeparam name="TProjection">The projection result type.</typeparam>
+        /// <returns>The projected results that match the query specification.</returns>
+        protected async Task<IReadOnlyList<TProjection>> FetchManyAsync<TProjection>(
+            IProjectedQuerySpecification<TAggregateRoot, TProjection> specification,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(specification);
+
+            return await FetchManyAsync(specification, specification.Projection, ct);
+        }
+
+        /// <summary>
+        /// Queries for a single entity from the query spec, returning null if
+        /// no result returned from the repository.
+        /// Throws an exception if multiple entities are found.
+        /// </summary>
+        /// <param name="fetchOneSpec">The single entity query specification.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>The aggregate root that matches the query specification, or null if none exists.</returns>
+        protected async Task<TAggregateRoot?> FetchSingleAsync(
+            ISingleEntityQuerySpecification<TAggregateRoot> fetchOneSpec, CancellationToken ct = default)
+        {
+            List<TAggregateRoot> results = await AsSingleResultQueryable(fetchOneSpec).ToListAsync(ct);
+            if (results.Count > 1)
+            {
+                throw new InvalidOperationException($"Expected single result, but found {results.Count}.");
+            }
+            return results.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Applies the query criteria and eager-loading includes, if any.
+        /// </summary>
+        /// <param name="singleEntityQuerySpecification">The single entity query specification.</param>
+        /// <returns>The resulting queryable.</returns>
+        protected IQueryable<TAggregateRoot> AsSingleResultQueryable(
+            ISingleEntityQuerySpecification<TAggregateRoot> singleEntityQuerySpecification)
+        {
+            ArgumentNullException.ThrowIfNull(singleEntityQuerySpecification);
+            IQueryable<TAggregateRoot> query = CreateQuery()
+                .Where(singleEntityQuerySpecification.Criteria);
+
+            if (singleEntityQuerySpecification.Includes != null)
+            {
+                foreach (Expression<Func<TAggregateRoot, object>> include in singleEntityQuerySpecification.Includes)
+                {
+                    query = query.Include(include);
+                }
+            }
+            return query;
+        }
+
+        /// <summary>
+        /// Applies the query specification to the EF DbSet for TAggregateRoot
+        /// and returns the resulting IQueryable of TAggregateRoot.
+        /// </summary>
+        /// <param name="querySpecification">The query specification.</param>
+        /// <returns>The resulting queryable.</returns>
+        protected IQueryable<TAggregateRoot> ApplySpecification(IQuerySpecification<TAggregateRoot> querySpecification)
+        {
+            ArgumentNullException.ThrowIfNull(querySpecification);
+            IQueryable<TAggregateRoot> query = CreateQuery();
+
+            if (querySpecification.Criteria != null)
+            {
+                query = query.Where(querySpecification.Criteria);
+            }
+
+            if (querySpecification.Includes != null)
+            {
+                foreach (Expression<Func<TAggregateRoot, object>> include in querySpecification.Includes)
+                {
+                    query = query.Include(include);
+                }
+            }
+
+            if (querySpecification.Orderings != null)
+            {
+                IOrderedQueryable<TAggregateRoot>? orderedQuery = null;
+
+                for (int i = 0; i < querySpecification.Orderings.Count; i++)
+                {
+                    QueryOrdering<TAggregateRoot> ordering = querySpecification.Orderings[i];
+
+                    if (i == 0)
+                    {
+                        orderedQuery = ordering.Direction == SortDirection.Ascending
+                            ? query.OrderBy(ordering.Expression)
+                            : query.OrderByDescending(ordering.Expression);
+                    }
+                    else
+                    {
+                        orderedQuery = ordering.Direction == SortDirection.Ascending
+                            ? orderedQuery!.ThenBy(ordering.Expression)
+                            : orderedQuery!.ThenByDescending(ordering.Expression);
+                    }
+                }
+                query = orderedQuery ?? query;
+            }
+
+            if (querySpecification.Page != null)
+            {
+                query = query.Skip(querySpecification.Page.Skip).Take(querySpecification.Page.Take);
+            }
+
+            return query;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            DbContext.Dispose();
+        }
+
+        /// <inheritdoc />
+        public async ValueTask DisposeAsync()
+        {
+            await DbContext.DisposeAsync();
+        }
+
+        private IQueryable<TAggregateRoot> CreateQuery()
+        {
+            IQueryable<TAggregateRoot> query = DbSet.AsQueryable();
+
+            if (UseNoTrackingQueries)
+            {
+                query = query.AsNoTracking();
+            }
+
+            return query;
+        }
+    }
+}

--- a/DomainDrivenDesign/Repositories-EF/EntityFrameworkRepositoryBase.cs
+++ b/DomainDrivenDesign/Repositories-EF/EntityFrameworkRepositoryBase.cs
@@ -1,200 +1,36 @@
 using Microsoft.EntityFrameworkCore;
-using System.Linq.Expressions;
 
 namespace Odin.DDD.Repositories
 {
     /// <summary>
-    /// Provides a base implementation for repositories that use Entity Framework Core for data access.
+    /// Provides a base implementation for read-write repositories that use Entity Framework Core for data access.
     /// Exposes flexible FetchSingleAsync and FetchManyAsync query endpoints.
     /// </summary>
     /// <typeparam name="TAggregateRoot"></typeparam>
     /// <typeparam name="TDbContext">The database context that must contain a DBSet of <typeparamref name="TAggregateRoot"/>
     /// We encapsulate save\commit under IUnitOfWork, in order that other commit-time aspects can be implemented,
     /// the most notable being domain event publishing.</typeparam>
-    public abstract class EntityFrameworkRepositoryBase<TAggregateRoot, TDbContext> : IRepository<TAggregateRoot>, IDisposable
+    public abstract class EntityFrameworkRepositoryBase<TAggregateRoot, TDbContext>
+        : EntityFrameworkReadOnlyRepositoryBase<TAggregateRoot, TDbContext>, IRepository<TAggregateRoot>
         where TDbContext : DbContext, IUnitOfWork
         where TAggregateRoot : class, IAggregateRoot
     {
-
-        /// <summary>
-        /// The context for database operations
-        /// </summary>
-        protected readonly TDbContext DbContext;
-
-        /// <summary>
-        /// The DbSet for the aggregate root type, TAggregateRoot.
-        /// </summary>
-        protected readonly DbSet<TAggregateRoot> DbSet;
-
         /// <summary>
         /// EntityFrameworkRepositoryBase constructor.
         /// </summary>
         /// <param name="dbContext"></param>
         /// <exception cref="ArgumentNullException"></exception>
         protected EntityFrameworkRepositoryBase(TDbContext dbContext)
+            : base(dbContext)
         {
-            ArgumentNullException.ThrowIfNull(dbContext);
-            DbContext = dbContext;
-            // If TAggregateRoot is a base type of the actual implementation type in the database context
-            // then this exception will be thrown which is no good.
-            // if (DbContext.Model.FindEntityType(typeof(TAggregateRoot)) == null)
-            // {
-            //     throw new InvalidOperationException(
-            //         $"The DbContext does not contain a DbSet for aggregate root type {typeof(TAggregateRoot).FullName}.");
-            // }
-            DbSet = DbContext.Set<TAggregateRoot>();
         }
 
         /// <summary>
-        /// Queries the repository based on the query specification.
+        /// Gets a value indicating whether queries should be created without EF change tracking.
         /// </summary>
-        /// <param name="fetchManySpec"></param>
-        /// <param name="ct"></param>
-        /// <returns></returns>
-        protected async Task<IReadOnlyList<TAggregateRoot>> FetchManyAsync(
-            IQuerySpecification<TAggregateRoot> fetchManySpec, CancellationToken ct = default)
+        protected override bool UseNoTrackingQueries
         {
-            return await ApplySpecification(fetchManySpec).ToListAsync(ct);
-        }
-
-        /// <summary>
-        /// Queries the repository based on the query specification, projecting TAggregateRoot
-        /// to TProjection.
-        /// </summary>
-        /// <param name="specification"></param>
-        /// <param name="projection"></param>
-        /// <param name="ct"></param>
-        /// <typeparam name="TProjection"></typeparam>
-        /// <returns></returns>
-        protected async Task<IReadOnlyList<TProjection>> FetchManyAsync<TProjection>(
-            IQuerySpecification<TAggregateRoot> specification,
-            Expression<Func<TAggregateRoot, TProjection>> projection,
-            CancellationToken ct = default)
-        {
-            ArgumentNullException.ThrowIfNull(projection);
-
-            return await ApplySpecification(specification)
-                .Select(projection)
-                .ToListAsync(ct);
-        }
-
-        /// <summary>
-        /// Queries the repository based on the projection query specification, projecting TAggregateRoot
-        /// to TProjection.
-        /// </summary>
-        /// <param name="specification"></param>
-        /// <param name="ct"></param>
-        /// <typeparam name="TProjection"></typeparam>
-        /// <returns></returns>
-        protected async Task<IReadOnlyList<TProjection>> FetchManyAsync<TProjection>(
-            IProjectedQuerySpecification<TAggregateRoot, TProjection> specification,
-            CancellationToken ct = default)
-        {
-            ArgumentNullException.ThrowIfNull(specification);
-
-            return await FetchManyAsync(specification, specification.Projection, ct);
-        }
-
-        /// <summary>
-        /// Queries for a single entity from the query spec, returning null if
-        /// no result returned from the repository.
-        /// Throws an exception if multiple entities are found.
-        /// </summary>
-        /// <param name="fetchOneSpec"></param>
-        /// <param name="ct"></param>
-        /// <returns></returns>
-        protected async Task<TAggregateRoot?> FetchSingleAsync(ISingleEntityQuerySpecification<TAggregateRoot> fetchOneSpec,
-            CancellationToken ct = default)
-        {
-            var results = await AsSingleResultQueryable(fetchOneSpec).ToListAsync(ct);
-            if (results.Count > 1)
-            {
-                throw new InvalidOperationException($"Expected single result, but found {results.Count}.");
-            }
-            return results.FirstOrDefault();
-        }
-
-        /// <summary>
-        /// Applies the query criteria and eager-loading includes, if any.
-        /// </summary>
-        /// <param name="singleEntityQuerySpecification"></param>
-        /// <returns></returns>
-        protected IQueryable<TAggregateRoot> AsSingleResultQueryable(
-            ISingleEntityQuerySpecification<TAggregateRoot> singleEntityQuerySpecification)
-        {
-            ArgumentNullException.ThrowIfNull(singleEntityQuerySpecification);
-            IQueryable<TAggregateRoot> query = DbSet.AsQueryable()
-                .Where(singleEntityQuerySpecification.Criteria);
-
-            // Apply includes
-            if (singleEntityQuerySpecification.Includes != null)
-            {
-                foreach (var include in singleEntityQuerySpecification.Includes)
-                {
-                    query = query.Include(include);
-                }
-            }
-            return query;
-        }
-
-        /// <summary>
-        /// Applies the query specification to the EF DbSet for TAggregateRoot
-        /// and returns the resulting IQueryable of TAggregateRoot.
-        /// </summary>
-        /// <param name="querySpecification"></param>
-        /// <returns></returns>
-        protected IQueryable<TAggregateRoot> ApplySpecification(IQuerySpecification<TAggregateRoot> querySpecification)
-        {
-            ArgumentNullException.ThrowIfNull(querySpecification);
-            IQueryable<TAggregateRoot> query = DbSet.AsQueryable();
-
-            // Apply criteria
-            if (querySpecification.Criteria != null)
-            {
-                query = query.Where(querySpecification.Criteria);
-            }
-
-            // Apply includes
-            if (querySpecification.Includes != null)
-            {
-                foreach (var include in querySpecification.Includes)
-                {
-                    query = query.Include(include);
-                }
-            }
-
-            // Apply ordering
-            if (querySpecification.Orderings != null)
-            {
-                IOrderedQueryable<TAggregateRoot>? orderedQuery = null;
-
-                for (int i = 0; i < querySpecification.Orderings.Count; i++)
-                {
-                    QueryOrdering<TAggregateRoot> ordering = querySpecification.Orderings[i];
-
-                    if (i == 0)
-                    {
-                        orderedQuery = ordering.Direction == SortDirection.Ascending
-                            ? query.OrderBy(ordering.Expression)
-                            : query.OrderByDescending(ordering.Expression);
-                    }
-                    else
-                    {
-                        orderedQuery = ordering.Direction == SortDirection.Ascending
-                            ? orderedQuery!.ThenBy(ordering.Expression)
-                            : orderedQuery!.ThenByDescending(ordering.Expression);
-                    }
-                }
-                query = orderedQuery ?? query;
-            }
-
-            // Apply paging
-            if (querySpecification.Page != null)
-            {
-                query = query.Skip(querySpecification.Page.Skip).Take(querySpecification.Page.Take);
-            }
-
-            return query;
+            get { return false; }
         }
 
         /// <inheritdoc />
@@ -227,16 +63,5 @@ namespace Odin.DDD.Repositories
             DbSet.Update(entity);
         }
 
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            DbContext.Dispose();
-        }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            await DbContext.DisposeAsync();
-        }
     }
 }

--- a/DomainDrivenDesign/Tests/Repositories/RepositoryContractTests.cs
+++ b/DomainDrivenDesign/Tests/Repositories/RepositoryContractTests.cs
@@ -1,0 +1,73 @@
+using Odin.DDD.Repositories;
+using Tests.Odin.DDD.Repositories.EF;
+using Tests.Odin.DDD.Repositories.EF.Entities;
+
+namespace Tests.Odin.DDD.Repositories;
+
+public sealed class RepositoryContractTests
+{
+    [Test]
+    public void Read_write_repository_is_a_read_only_repository()
+    {
+        Assert.That(
+            typeof(IReadOnlyRepository<BillingPeriod>).IsAssignableFrom(typeof(IRepository<BillingPeriod>)),
+            Is.True);
+    }
+
+    [Test]
+    public void Entity_framework_read_only_repository_does_not_implement_read_write_contract()
+    {
+        Assert.That(
+            typeof(IRepository<BillingPeriod>).IsAssignableFrom(typeof(ReadOnlyBillingPeriodRepository)),
+            Is.False);
+    }
+
+    [Test]
+    public void Entity_framework_repository_implements_read_write_and_read_only_contracts()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                typeof(IRepository<BillingPeriod>).IsAssignableFrom(typeof(ReadWriteBillingPeriodRepository)),
+                Is.True);
+            Assert.That(
+                typeof(IReadOnlyRepository<BillingPeriod>).IsAssignableFrom(typeof(ReadWriteBillingPeriodRepository)),
+                Is.True);
+        });
+    }
+
+    [Test]
+    public void Entity_framework_read_only_identity_repository_implements_read_only_contract()
+    {
+        Assert.That(
+            typeof(IReadOnlyRepository<BillingEntity>).IsAssignableFrom(typeof(ReadOnlyBillingEntityRepository)),
+            Is.True);
+    }
+
+    private sealed class ReadOnlyBillingPeriodRepository
+        : EntityFrameworkReadOnlyRepositoryBase<BillingPeriod, TestDatabaseContext>
+    {
+        public ReadOnlyBillingPeriodRepository(TestDatabaseContext dbContext)
+            : base(dbContext)
+        {
+        }
+    }
+
+    private sealed class ReadWriteBillingPeriodRepository
+        : EntityFrameworkRepositoryBase<BillingPeriod, TestDatabaseContext>
+    {
+        public ReadWriteBillingPeriodRepository(TestDatabaseContext dbContext)
+            : base(dbContext)
+        {
+        }
+    }
+
+    private sealed class ReadOnlyBillingEntityRepository
+        : EntityFrameworkReadOnlyIdentityRepositoryBase<BillingEntity, int, TestDatabaseContext>
+    {
+        public ReadOnlyBillingEntityRepository(TestDatabaseContext dbContext)
+            : base(dbContext)
+        {
+        }
+    }
+}

--- a/DomainDrivenDesign/Tests/Tests.Odin.DDD.csproj
+++ b/DomainDrivenDesign/Tests/Tests.Odin.DDD.csproj
@@ -34,6 +34,7 @@
         <ProjectReference Include="..\..\System\Result\Odin.System.Result.csproj"/>
         <ProjectReference Include="..\..\System\Strings\Odin.System.Strings.csproj" />
         <ProjectReference Include="..\Core\Odin.DDD.csproj"/>
+        <ProjectReference Include="..\Repositories-EF\Odin.DDD.Repositories.EF.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Introduce `IReadOnlyRepository<TAggregateRoot>` and make `IRepository<TAggregateRoot>` extend it, so read-only and read-write repository contracts are explicit.
- Split the EF base implementation into a read-only base with no-tracking query defaults and a write base layered on top.
- Add a read-only identity repository base and contract tests covering the new inheritance shape.

## Testing
- `dotnet test DomainDrivenDesign/Tests/Tests.Odin.DDD.csproj -f net10.0 --filter "Category!=IntegrationTest"`
- `dotnet test DomainDrivenDesign/Tests/Tests.Odin.DDD.csproj -f net9.0 --filter "Category!=IntegrationTest"`
- `dotnet test DomainDrivenDesign/Tests/Tests.Odin.DDD.csproj -f net8.0 --filter "Category!=IntegrationTest"`
- Validation passed; existing repo warnings about the missing `System/Strings` project reference and known package advisories remain.